### PR TITLE
Editorial-review skill + writing-page features

### DIFF
--- a/.claude/skills/editorial-review/SKILL.md
+++ b/.claude/skills/editorial-review/SKILL.md
@@ -98,7 +98,7 @@ This list grows as the writer notices their own tells. To add a new entry, appen
 ## Output Rules
 
 - **Verdict comes first. Always.** The "is this piece working?" call must precede line edits, even under time pressure.
-- **Verdict-tier dimensions (Hook, Through-line, Ending) appear in the Verdict pass ONLY.** Do not re-list them in Issues — that creates redundancy and dilutes the structural-vs-mechanical distinction.
+- **Verdict-tier dimensions (Hook, Through-line, Ending) appear in the Verdict pass ONLY.** Do not re-list them in Issues — that creates redundancy and dilutes the structural-vs-mechanical distinction. **This applies to substance, not just dimension name:** an Issue titled "Completeness", "Closure", "Resolution", "Opening", "Lede", or any other label is still a verdict-tier issue if the substance is about the post's beginning, argument-spine, or end. Move it to the Verdict pass.
 - **Verdict-level rewrite directions are generated only for ⚠ / ✗.** No busywork on what's already working.
 - **Mechanical issues (Style A) end at "What's wrong" — no rewrite given.** The writer fixes it. This is intentional; it's how learning happens.
 - **Every issue quotes the post directly with a paragraph marker.** Anchor every finding to specific text.
@@ -134,6 +134,9 @@ If you find yourself thinking any of these while producing a review, stop and re
 - "The user said 'quick pass' — I'll just give bullets."
 - "Em dashes are stylistic preference, I'll let it slide."
 - "I don't need to quote the post, the user wrote it."
-- "The ending is broken, I'll put it in Issues so the writer has a concrete action item." ← NO. The Verdict pass already gives 2–3 rewrite directions for any ✗ dimension. Adding it to Issues creates duplicate, conflicting instructions. **Before finalizing Issues, remove any item whose dimension is Hook, Through-line, or Ending.**
+- "The ending is broken, I'll put it in Issues so the writer has a concrete action item." ← NO. The Verdict pass already gives 2–3 rewrite directions for any ✗ dimension. Adding it to Issues creates duplicate, conflicting instructions.
+- "I'll rename the dimension to 'Completeness' / 'Closure' / 'Lede' / 'Opening' so it's not technically a verdict-tier item." ← NO. The rule is about substance. If the issue is about the post's beginning, argument-spine, or end, it belongs in the Verdict pass regardless of label.
+
+**Before finalizing the Issues list, run this scan:** for every Issue, ask "is this issue about the hook/opening, the central argument, or the ending/landing of the post?" If yes for any of them, that issue belongs in the Verdict pass — delete it from Issues.
 
 All of these mean: re-read the rubric and produce the report as specified.

--- a/.claude/skills/editorial-review/SKILL.md
+++ b/.claude/skills/editorial-review/SKILL.md
@@ -98,6 +98,7 @@ This list grows as the writer notices their own tells. To add a new entry, appen
 ## Output Rules
 
 - **Verdict comes first. Always.** The "is this piece working?" call must precede line edits, even under time pressure.
+- **Verdict-tier dimensions (Hook, Through-line, Ending) appear in the Verdict pass ONLY.** Do not re-list them in Issues — that creates redundancy and dilutes the structural-vs-mechanical distinction.
 - **Verdict-level rewrite directions are generated only for ⚠ / ✗.** No busywork on what's already working.
 - **Mechanical issues (Style A) end at "What's wrong" — no rewrite given.** The writer fixes it. This is intentional; it's how learning happens.
 - **Every issue quotes the post directly with a paragraph marker.** Anchor every finding to specific text.
@@ -109,7 +110,7 @@ This list grows as the writer notices their own tells. To add a new entry, appen
 
 ## Calibration: See `example-review.md`
 
-Before producing a review, read `example-review.md` in this skill directory. It is a complete worked review of `content/posts/add.mdx` and is the calibration model for tone, depth, and specificity.
+Before producing a review, read `.claude/skills/editorial-review/example-review.md`. It is a complete worked review of `content/posts/add.mdx` and is the calibration model for tone, depth, and specificity.
 
 ## Common Mistakes
 

--- a/.claude/skills/editorial-review/SKILL.md
+++ b/.claude/skills/editorial-review/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: editorial-review
+description: Use when the user asks for editorial review, writing feedback, critique, or "is this ready to publish" on a blog post in content/posts/*.mdx, or when flipping a post's frontmatter from published:false to published:true
+---
+
+# Editorial Review
+
+## Overview
+
+Editorial-craft review for blog posts. Produces a **verdict-first, principle-driven** review that names what's working, what isn't, and *why* — so the writer fixes the post and learns the principle behind each fix.
+
+This is **not** a grammar pass and **not** a literary-prose review. Reference style: essay editors at *The Atlantic*, Paul Graham essays.
+
+The skill exists to do two things at once:
+1. Improve posts before publish.
+2. Build the writer's craft over time — feedback teaches principles, doesn't just hand out fixes.
+
+## When to Use
+
+Use when **either** is true:
+
+- The user asks for review / feedback / critique / "is this ready to publish?" on a file in `content/posts/`.
+- The user is flipping a post's frontmatter from `published: false` to `published: true`.
+
+Do NOT use during raw drafting. Generative writing and critical review are different modes; running this skill mid-draft is harmful.
+
+## Output: Two-Pass Report
+
+Save the review to `content/posts/<slug>.review.md` (gitignored — does not ship).
+
+The report has exactly two passes, in this order. **Verdict always comes first.**
+
+```markdown
+# Review: <post title>
+*Reviewed <date> · word count: <n>*
+
+## Verdict
+
+**Through-line (one sentence I'd write for this piece):** <state the thesis as you read it>
+
+**Hook:** ✓ / ⚠ / ✗ — <1–2 sentences>
+**Through-line:** ✓ / ⚠ / ✗ — <1–2 sentences>
+**Ending / payoff:** ✓ / ⚠ / ✗ — <1–2 sentences>
+
+**Verdict-level rewrite directions** (only for ⚠ / ✗):
+- *Hook, option 1:* <direction>
+- *Hook, option 2:* <direction>
+- *Through-line, option 1:* …
+  *(2–3 directions per failing verdict dimension)*
+
+**One-line verdict:** <e.g., "structurally working — polish only" / "thesis not visible — global rewrite before line edits">
+
+---
+
+## Issues (prioritized)
+
+### 1. <Dimension> — <short title>
+> "<exact quote from the post>" *(¶N)*
+
+**Principle:** <one-line principle from the rubric>
+**What's wrong:** <1–2 sentences specific to this instance>
+**Suggested rewrite** *(only for tier-2 judgment issues — flow / structure / voice / originality)*: <one concrete rewrite>
+
+### 2. …
+```
+
+## The Rubric (11 dimensions)
+
+| # | Dimension | What to look for | Principle | Tier | Style |
+|---|---|---|---|---|---|
+| 1 | **Hook** | Does paragraph 1 give the reader a reason to keep reading? Specific, surprising, stake-raising? | An opening earns the next 30 seconds. Vague stage-setting loses the reader. | Verdict | C |
+| 2 | **Through-line** | Can the piece's argument be stated in one sentence? Does every paragraph serve it? | If you can't write the thesis in one sentence, the reader can't find it. | Verdict | C |
+| 3 | **Ending / payoff** | Does the piece land somewhere the reader couldn't have predicted from the opening? | The ending is the contract — the opening promised insight, the ending must deliver it. | Verdict | C |
+| 4 | **Argument flow** | Does each paragraph advance the through-line, or does it loop, repeat, or wander? | Every paragraph should make the reader more convinced or more curious. If it doesn't, cut or move it. | Issues | B |
+| 5 | **Specificity** | Vague subjects ("they", "people", "big tech"), unsupported claims, abstractions without examples | Concrete beats abstract. Name the actor, cite the source, or cut the claim. | Issues | A |
+| 6 | **Paragraph structure** | One idea per paragraph; over-long paragraphs split; one-line paragraphs merged | Paragraph breaks are punctuation for thought. Each break = new beat. | Issues | B |
+| 7 | **Header–payoff coupling** | When a section header poses a question or claim, does the paragraph immediately address it? | Headers are promises. Break the promise and the reader stops trusting you. | Issues | A |
+| 8 | **Clarity** | Pronouns without antecedents; jargon not explained or cut; sentences requiring re-reading | If a sentence makes the reader work, the writer hasn't finished working. | Issues | A |
+| 9 | **Voice consistency** | Drift between conversational and formal mid-piece; tonal whiplash | Pick a register and stay in it. Drift signals uncertainty about audience. | Issues | B |
+| 10 | **Originality of take** | Conventional wisdom presented as insight; restating what the reader already believes | The reader's time is bought by giving them something they didn't already think. | Issues | B |
+| 11 | **Style watch** | See list below. Extensible. | If a period, comma, or colon would carry the same load, use it. Em dashes signal hedging or stitched half-thoughts and now read as machine-generated. | Issues | A |
+
+### Feedback Style Legend
+
+- **A — Diagnose only.** Issue + principle. No rewrite. Used for mechanical issues (5, 7, 8, 11). Reader fixes it themselves to internalize the principle.
+- **B — Diagnose + one suggested rewrite.** Used for judgment issues with one clearly better direction (4, 6, 9, 10).
+- **C — Diagnose + 2–3 rewrite directions.** Used for verdict-tier dimensions (1, 2, 3) where the choice is structural.
+
+### Style Watch List (extensible)
+
+This list grows as the writer notices their own tells. To add a new entry, append to this section.
+
+1. **Em dashes (`—`) used as connective tissue.** Default suspicion: high — em dashes are now an AI tell readers spot fast. Flag every instance unless the dash is doing work a comma/colon/period cannot.
+   - *Example:* `"ultimately generative AI — which for the past ~3 years..."` → connective tissue, swap for a period or "that".
+
+(Append future entries here as the writer identifies them.)
+
+## Output Rules
+
+- **Verdict comes first. Always.** The "is this piece working?" call must precede line edits, even under time pressure.
+- **Verdict-level rewrite directions are generated only for ⚠ / ✗.** No busywork on what's already working.
+- **Mechanical issues (Style A) end at "What's wrong" — no rewrite given.** The writer fixes it. This is intentional; it's how learning happens.
+- **Every issue quotes the post directly with a paragraph marker.** Anchor every finding to specific text.
+- **Issue count follows the post:**
+  - Typical draft: top 5–10 issues.
+  - Polished post: 2–3 flags is fine. **Never invent issues to fill a quota.**
+  - Very rough draft: cap at 10 and note the rest exist.
+- The skill must **prioritize, not exhaust**.
+
+## Calibration: See `example-review.md`
+
+Before producing a review, read `example-review.md` in this skill directory. It is a complete worked review of `content/posts/add.mdx` and is the calibration model for tone, depth, and specificity.
+
+## Common Mistakes
+
+| Mistake | Why it's wrong | Fix |
+|---|---|---|
+| Skipping the verdict pass under time pressure | Line edits without a verdict produce polish on a piece that may not be working at all. | Always verdict first. Shorten the issues list if pressed for time, never skip the verdict. |
+| Inventing issues to hit "5–10" | Quota-filling makes the writer fix non-issues and erodes trust in the review. | Honor the actual quality of the post. Polished posts get 2–3 flags. |
+| Wholesale rewrite for mechanical issues | Removes the learning. Writer ships the post but doesn't internalize the principle. | Style A means principle-only. No rewrite. Resist requests to "just rewrite it." |
+| Listing every issue exhaustively | Reader can't act on 30 flags. Top-N forces prioritization. | Pick highest-impact issues. Note that more exist if needed. |
+| Generic feedback ("this is unclear") | Doesn't teach. Writer can't generalize from it. | Always state the principle from the rubric. |
+| Failing to quote the post | Writer can't find the spot. Feedback becomes abstract. | Every issue gets a `> "quote" (¶N)` line. |
+
+## Red Flags — STOP and re-check
+
+If you find yourself thinking any of these while producing a review, stop and re-read the rubric:
+
+- "I'll skip the verdict — the piece is short, it's fine."
+- "Just this once I'll rewrite a Style-A issue, it's faster."
+- "I should add a few more issues to make this feel thorough."
+- "The user said 'quick pass' — I'll just give bullets."
+- "Em dashes are stylistic preference, I'll let it slide."
+- "I don't need to quote the post, the user wrote it."
+
+All of these mean: re-read the rubric and produce the report as specified.

--- a/.claude/skills/editorial-review/SKILL.md
+++ b/.claude/skills/editorial-review/SKILL.md
@@ -24,6 +24,36 @@ Use when **either** is true:
 
 Do NOT use during raw drafting. Generative writing and critical review are different modes; running this skill mid-draft is harmful.
 
+## Author scratchpad blocks (not in scope)
+
+Drafts often contain author-side scratchpad blockquotes the writer left for themselves about what to write next. These are drafting aids, not copy that will ship. Treat them as out of scope for the review.
+
+**How to detect one:** a blockquote whose first token is `Mental Note`, `TODO`, `Note to self`, `Draft note`, or whose content is plainly an instruction the writer wrote to themselves ("I want to talk about…", "remember to mention…"). When in doubt, ask the user before flagging.
+
+**How to handle:**
+
+- Do not flag the block itself as a paragraph-structure problem, voice slip, or "draft scaffold visible." It isn't part of the post.
+- Do not raise Issues against a section whose body is *only* a scratchpad block. There's no copy there to critique yet. In particular, do not flag header–payoff coupling, specificity, or argument flow inside such a section.
+- The **Ending / payoff** verdict still applies normally. If the post has no real ending yet, that is still ✗, but say in the verdict line that the second half is a known scratchpad and that fixing the landing *now* is what shapes the eventual draft.
+- If the post is mostly scratchpad with little written copy, this skill isn't the right tool yet. Say so and stop, rather than reviewing the sketch.
+
+**Anchoring inside a scratchpad:** the only acceptable reason to quote
+*from* a scratchpad block is to surface a spelling typo in a header users
+will skim, or to note an item for completeness inside an Issue 5-style
+typo cluster. When you do, use the scratchpad anchor form:
+`*(§N scratchpad — out of scope, <reason>)*` (or the dotted form
+`*(§N.M scratchpad — ...)*` for scratchpads inside an H3). The `— out of
+scope` clause is mandatory — it's how downstream tooling detects that the
+anchor points into non-shipping copy. See `md_references.md` for the
+full spec.
+
+**Status-line convention:** when a post contains scratchpad blocks, the
+review's status line notes them so a downstream reader (or tool) knows
+the post isn't a finished draft, e.g. *"status: published:false
+(mid-draft; the `> Mental Note:` blocks under §4 and §5 are author
+scratchpad, out of scope for this pass)"*. The phrase `out of scope for
+this pass` is the canonical signal.
+
 ## Output: Two-Pass Report
 
 Save the review to `content/posts/<slug>.review.md` (gitignored — does not ship).
@@ -55,7 +85,7 @@ The report has exactly two passes, in this order. **Verdict always comes first.*
 ## Issues (prioritized)
 
 ### 1. <Dimension> — <short title>
-> "<exact quote from the post>" *(¶N)*
+> "<exact quote from the post>" *(<anchor>)*
 
 **Principle:** <one-line principle from the rubric>
 **What's wrong:** <1–2 sentences specific to this instance>
@@ -63,6 +93,38 @@ The report has exactly two passes, in this order. **Verdict always comes first.*
 
 ### 2. …
 ```
+
+### Reference Anchors
+
+Every quote in the review must be anchored to a location in the source `.mdx`
+using the conventions in [`md_references.md`](./md_references.md). The
+authoritative spec lives there; this section is a quick reference.
+
+Anchors are wrapped in italicized parentheses: `*(<target>)*`. The target
+is one of:
+
+| Form                                     | Meaning                                                          |
+|------------------------------------------|------------------------------------------------------------------|
+| `¶N`                                     | Nth prose paragraph in the pre-section region (before any H2).  |
+| `§N`                                     | Nth H2 section (also written `§N header`).                       |
+| `§N ¶M`                                  | Mth prose paragraph inside the Nth H2 section.                   |
+| `§N.M`                                   | Mth H3 inside the Nth H2 (dotted path; extends out to H6).       |
+| `§N.M ¶K`                                | Kth prose paragraph inside that H3.                              |
+| `§N header`                              | The H2 heading line itself (and analogously `§N.M header`).      |
+| `§N, final sentence`                     | The last sentence of the Nth section's last addressable block.   |
+| `§N, post-scratchpad`                    | First prose paragraph after a scratchpad block inside the scope. |
+| `§N scratchpad — out of scope, <reason>` | A token inside a scratchpad blockquote; non-actionable.          |
+| `¶A–¶B`                                  | Range of paragraphs (en-dash, U+2013).                           |
+
+**Counting rules** (full spec in `md_references.md`):
+- Frontmatter is skipped.
+- Only H2 and deeper headings affect the path; H1 is ignored.
+- Each heading increments its level's sibling counter and resets `¶ = 0`.
+- Sibling indices reset per parent: two different H2s each get their own
+  `.1`, `.2`, ... children.
+- Scratchpad blockquotes (first token `Mental Note`, `TODO`, `Note to self`,
+  `Draft note`) do not count as paragraphs and never increment `¶`.
+- Two prose blocks separated only by a scratchpad block are consecutive `¶`.
 
 ## The Rubric (11 dimensions)
 
@@ -101,7 +163,7 @@ This list grows as the writer notices their own tells. To add a new entry, appen
 - **Verdict-tier dimensions (Hook, Through-line, Ending) appear in the Verdict pass ONLY.** Do not re-list them in Issues — that creates redundancy and dilutes the structural-vs-mechanical distinction. **This applies to substance, not just dimension name:** an Issue titled "Completeness", "Closure", "Resolution", "Opening", "Lede", or any other label is still a verdict-tier issue if the substance is about the post's beginning, argument-spine, or end. Move it to the Verdict pass.
 - **Verdict-level rewrite directions are generated only for ⚠ / ✗.** No busywork on what's already working.
 - **Mechanical issues (Style A) end at "What's wrong" — no rewrite given.** The writer fixes it. This is intentional; it's how learning happens.
-- **Every issue quotes the post directly with a paragraph marker.** Anchor every finding to specific text.
+- **Every issue quotes the post directly with a reference anchor.** Anchor every finding to specific text using the conventions in `md_references.md` (e.g. `*(¶1)*`, `*(§2 ¶3)*`, `*(§2.1 header)*`).
 - **Issue count follows the post:**
   - Typical draft: top 5–10 issues.
   - Polished post: 2–3 flags is fine. **Never invent issues to fill a quota.**
@@ -112,6 +174,10 @@ This list grows as the writer notices their own tells. To add a new entry, appen
 
 Before producing a review, read `.claude/skills/editorial-review/example-review.md`. It is a complete worked review of `content/posts/add.mdx` and is the calibration model for tone, depth, and specificity.
 
+## Anchor Spec: See `md_references.md`
+
+The reference-anchor conventions used throughout reviews (paragraph numbering, dotted section paths for H2–H6, scratchpad anchors, ranges) are specified in `.claude/skills/editorial-review/md_references.md`. That file is the authoritative source — read it once if you're unsure how to address a location, and follow its grammar exactly so editor tooling can resolve anchors back to source-file positions.
+
 ## Common Mistakes
 
 | Mistake | Why it's wrong | Fix |
@@ -121,7 +187,8 @@ Before producing a review, read `.claude/skills/editorial-review/example-review.
 | Wholesale rewrite for mechanical issues | Removes the learning. Writer ships the post but doesn't internalize the principle. | Style A means principle-only. No rewrite. Resist requests to "just rewrite it." |
 | Listing every issue exhaustively | Reader can't act on 30 flags. Top-N forces prioritization. | Pick highest-impact issues. Note that more exist if needed. |
 | Generic feedback ("this is unclear") | Doesn't teach. Writer can't generalize from it. | Always state the principle from the rubric. |
-| Failing to quote the post | Writer can't find the spot. Feedback becomes abstract. | Every issue gets a `> "quote" (¶N)` line. |
+| Failing to quote the post | Writer can't find the spot. Feedback becomes abstract. | Every issue gets a `> "quote" *(<anchor>)*` line using `md_references.md` conventions. |
+| Using ad-hoc anchor formats (`(P3)`, `(section 2 paragraph 3)`, page numbers) | Anchors are machine-readable so the writer's editor can jump to the location. Non-spec anchors break that. | Use the `md_references.md` forms: `*(¶N)*`, `*(§N ¶M)*`, `*(§N.M ¶K)*`, etc. |
 | Re-listing Hook/Through-line/Ending in Issues | Doubles the work, dilutes the structural-vs-mechanical distinction, and sends the writer two conflicting sets of directions for the same problem. | After writing the Verdict pass, scan the Issues list and remove any item whose dimension is Hook, Through-line, or Ending. Verdict pass already covers it with rewrite directions. |
 
 ## Red Flags — STOP and re-check
@@ -136,6 +203,7 @@ If you find yourself thinking any of these while producing a review, stop and re
 - "I don't need to quote the post, the user wrote it."
 - "The ending is broken, I'll put it in Issues so the writer has a concrete action item." ← NO. The Verdict pass already gives 2–3 rewrite directions for any ✗ dimension. Adding it to Issues creates duplicate, conflicting instructions.
 - "I'll rename the dimension to 'Completeness' / 'Closure' / 'Lede' / 'Opening' so it's not technically a verdict-tier item." ← NO. The rule is about substance. If the issue is about the post's beginning, argument-spine, or end, it belongs in the Verdict pass regardless of label.
+- "I'll flag the `> Mental Note: …` block as a draft scaffold left in the post." ← NO. Scratchpad blockquotes (Mental Note / TODO / Note to self) are author drafting aids, not copy. They're out of scope. See *Author scratchpad blocks (not in scope)*.
 
 **Before finalizing the Issues list, run this scan:** for every Issue, ask "is this issue about the hook/opening, the central argument, or the ending/landing of the post?" If yes for any of them, that issue belongs in the Verdict pass — delete it from Issues.
 

--- a/.claude/skills/editorial-review/SKILL.md
+++ b/.claude/skills/editorial-review/SKILL.md
@@ -122,6 +122,7 @@ Before producing a review, read `.claude/skills/editorial-review/example-review.
 | Listing every issue exhaustively | Reader can't act on 30 flags. Top-N forces prioritization. | Pick highest-impact issues. Note that more exist if needed. |
 | Generic feedback ("this is unclear") | Doesn't teach. Writer can't generalize from it. | Always state the principle from the rubric. |
 | Failing to quote the post | Writer can't find the spot. Feedback becomes abstract. | Every issue gets a `> "quote" (¶N)` line. |
+| Re-listing Hook/Through-line/Ending in Issues | Doubles the work, dilutes the structural-vs-mechanical distinction, and sends the writer two conflicting sets of directions for the same problem. | After writing the Verdict pass, scan the Issues list and remove any item whose dimension is Hook, Through-line, or Ending. Verdict pass already covers it with rewrite directions. |
 
 ## Red Flags — STOP and re-check
 
@@ -133,5 +134,6 @@ If you find yourself thinking any of these while producing a review, stop and re
 - "The user said 'quick pass' — I'll just give bullets."
 - "Em dashes are stylistic preference, I'll let it slide."
 - "I don't need to quote the post, the user wrote it."
+- "The ending is broken, I'll put it in Issues so the writer has a concrete action item." ← NO. The Verdict pass already gives 2–3 rewrite directions for any ✗ dimension. Adding it to Issues creates duplicate, conflicting instructions. **Before finalizing Issues, remove any item whose dimension is Hook, Through-line, or Ending.**
 
 All of these mean: re-read the rubric and produce the report as specified.

--- a/.claude/skills/editorial-review/example-review.md
+++ b/.claude/skills/editorial-review/example-review.md
@@ -1,0 +1,100 @@
+# Review: The start of the super human era
+*Reviewed 2026-05-01 · word count: ~340 · status: published:false (draft)*
+
+> This file is the calibration model for the `editorial-review` skill. It is a real review of `content/posts/add.mdx`. The post is mid-draft, which is why findings are dense — your reviews on more polished posts will be shorter.
+
+## Verdict
+
+**Through-line (one sentence I'd write for this piece):** *AI agents won't replace engineers — engineers using AI will become "super humans," and the craft is now about understanding the code your agents write.*
+
+**Hook:** ⚠ — Opens with a personal time-frame ("For the past 2 years…") and a generic industry observation. The actual surprising claim ("agents are NOT the new engineers") doesn't appear until ¶4. The reader has no reason to commit before then.
+
+**Through-line:** ⚠ — The thesis is real and worth making, but it's not stated until ¶6 (`"What if instead of automated agents, a new concept gets minted: **Super Humans**"`). Paragraphs 1–3 are throat-clearing. The piece treats the late-80s internet analogy as the through-line for too long before pivoting.
+
+**Ending / payoff:** ✗ — The piece does not end. It cuts off mid-sentence in the "What is Agentic Development?" section: `"juggling loop between writing code by hand and orchestrating simple agent tasks like building tests for the code I wrote or simpler CSS changes."` The reader is dropped, not landed.
+
+**Verdict-level rewrite directions:**
+
+- *Hook, option 1 — open with the contrarian claim:* "Everyone with AI tools thought agents would be the new engineers. They're not. They can't be. Here's what they actually are." Puts the surprising claim first; analogy supports it later.
+- *Hook, option 2 — open with the late-80s analogy as the lede, not the back-up:* "In the late 80s, people said the internet would reshape every industry. It didn't. It became its own industry, useful inside other businesses but never the great replacer. AI is now in the same place." Earns the comparison upfront and makes it load-bearing.
+- *Hook, option 3 — open with a concrete moment:* "Last week I watched an agent get stuck on a problem a junior engineer would have solved in a minute. It wasn't a bad model. It was the wrong job for any model." Specific, low-stakes, sets up the bigger argument.
+- *Through-line, option 1:* Cut ¶1–¶3 entirely. Open with the "Super Humans" claim from ¶6. Use the internet analogy as a single supporting paragraph after the thesis, not as the runway.
+- *Through-line, option 2:* Keep the analogy as the opening but tighten ¶1–¶3 from ~150 words to ~60. The reader needs the reframe (`I think the same is happening with AI`) within the first 100 words, not the first 250.
+- *Ending, option 1:* End on the inversion — what the engineer's job actually becomes. "The new craft isn't writing code. It's reading the code your agents wrote and knowing whether they're right." Lands the contract the opening promised.
+- *Ending, option 2:* End with a stake. "If you treat your agents as colleagues, you'll plateau. If you treat them as power tools, you'll keep going." Memorable, debatable, quotable.
+
+**One-line verdict:** *Strong thesis buried under throat-clearing and an unfinished ending. Needs a global revision pass before line edits — the structural fix changes which line edits matter.*
+
+---
+
+## Issues (prioritized)
+
+### 1. Argument flow — ¶1–¶3 delay the thesis by ~250 words
+> "For the past 2 years I've been working with AI tools as most of us have, we've been told over and over that software will no longer be made by humans. I think that's wrong..." *(¶1)*
+
+**Principle:** Every paragraph should make the reader more convinced or more curious. If it doesn't, cut or move it.
+**What's wrong:** The first three paragraphs do work the rest of the piece doesn't need. ¶1 sets up the disagreement, ¶2 reaches for the internet analogy, ¶3 restates the thesis ("All of that to respond…"). By the time the reader hits "Super Humans" in ¶6, the argument has already been made twice in lower-resolution form.
+**Suggested rewrite:** Cut ¶1 and ¶3. Move the analogy from ¶2 to a single supporting paragraph *after* the "Super Humans" claim. Net cut: ~150 words; the piece earns its thesis 3× faster.
+
+### 2. Specificity — "they said" with no antecedent (¶2)
+> "Back in the late 80's they said that the internet will reshape all industries..." *(¶2)*
+
+**Principle:** Concrete beats abstract. Name the actor, cite the source, or cut the claim.
+**What's wrong:** "They" has no antecedent. The reader has to either accept the claim on faith or ignore it. A reference to *who* said this (analysts, journalists, McLuhan-era thinkers, a specific magazine cover) makes the analogy land harder and less generic.
+
+### 3. Style watch — em dash as connective tissue (¶2)
+> "...generative AI — which for the past ~3 years has been the biggest catalyst across multiple industries..." *(¶2)*
+
+**Principle:** If a period, comma, or colon would carry the same load, use it. Em dashes signal hedging or stitched half-thoughts and now read as machine-generated.
+**What's wrong:** This em dash is doing comma duty. Replace with a comma or end the sentence and start a new one with "Generative AI…".
+
+### 4. Style watch — em dash as connective tissue (¶2)
+> "...especially in today's market where competitiveness is rising by the day. The baseline things making that possible are better technologies, innovation, and ultimately generative AI — which for the past ~3 years..."
+
+**Principle:** Same as above.
+**What's wrong:** Two em dashes inside two consecutive sentences in ¶2. The pattern is a tell — em dashes used to extend a thought past its natural end. Cut both.
+
+### 5. Header–payoff coupling — `## What is Agentic Development?` opens with anecdote, not definition
+> "## What is Agentic Development?
+>
+> For the past 1.5 years or so, I've been working in a juggling loop between writing code by hand and orchestrating simple agent tasks..." *(after the H2)*
+
+**Principle:** Headers are promises. Break the promise and the reader stops trusting you.
+**What's wrong:** The header asks "what *is* it?" The paragraph starts with "I've been working in a juggling loop" — that's *what I do*, not *what it is*. The header promised a definition; deliver one in the first sentence ("Agentic development is X"), then use the anecdote to illustrate.
+
+### 6. Ending — the piece stops mid-thought
+> "...orchestrating simple agent tasks like building tests for the code I wrote or simpler CSS changes." *(end of file)*
+
+**Principle:** The ending is the contract — the opening promised insight, the ending must deliver it.
+**What's wrong:** The piece ends inside an example list, not on a landing. Even as a draft, this is the single biggest reason the post can't ship. The "What is Agentic Development?" section needs to actually answer its own question and connect back to the "Super Humans" thesis.
+
+### 7. Originality — "the internet was just its own industry" (¶2)
+> "Back in the late 80's they said that the internet will reshape all industries, it turned out to be just its own industry that was able to improve things in other businesses but definitely not the business killer that was promised." *(¶2)*
+
+**Principle:** The reader's time is bought by giving them something they didn't already think.
+**What's wrong:** This claim is contestable enough that it needs either an example or a more careful framing. As written, the sharper read is *"the internet did reshape every industry — retail, finance, media, advertising — it just took 20 years and the second wave (mobile + cloud)."* If the analogy is going to load-bear the AI argument, it can't be a wave-of-the-hand version of internet history.
+**Suggested rewrite:** Tighten the analogy to its strongest form: "The internet didn't kill industries. It made the businesses that adopted it well 10× more powerful, and made the ones that didn't disappear. AI is the same."
+
+### 8. Clarity — typo "prooven"
+> "Now that full autonomy has been prooven not reliable..." *(¶7)*
+
+**Principle:** If a sentence makes the reader work, the writer hasn't finished working.
+**What's wrong:** Typo: "prooven" → "proven". Also "prooven not reliable" reads awkwardly; "proven unreliable" is tighter.
+
+### 9. Voice consistency — register drifts between conversational and analytical
+> "I know this sounds yet like another random concept, but it's where the industry is naturally orbiting towards." *(¶7)*
+
+**Principle:** Pick a register and stay in it. Drift signals uncertainty about audience.
+**What's wrong:** "I know this sounds yet like another random concept" is conversational and slightly hedged. The very next clause ("the industry is naturally orbiting towards") is analyst-speak. The piece is most alive in its conversational register; lean into that and cut the analyst phrasing.
+**Suggested rewrite:** "I know — another concept. But this one is where the industry is already heading."
+
+### 10. Paragraph structure — ¶2 packs analogy + setup + claim into one block
+> *(¶2 — entire paragraph from "I think the same..." through "...especially software.")*
+
+**Principle:** Paragraph breaks are punctuation for thought. Each break = new beat.
+**What's wrong:** ¶2 contains three beats: (1) the AI claim, (2) why AI matters competitively, (3) AI as catalyst across industries. Each beat would land harder as its own short paragraph or be cut.
+**Suggested rewrite:** Split into 2–3 short paragraphs, or — if the post is moving toward a tighter open per Verdict option 1 — cut to just the catalyst beat.
+
+---
+
+*Total findings: 10 issues + verdict pass. Most are downstream of the structural problems flagged in the verdict; fixing the global structure (cut ¶1–¶3, write a real ending, deliver the H2's promise) collapses several of them.*

--- a/.claude/skills/editorial-review/example-review.md
+++ b/.claude/skills/editorial-review/example-review.md
@@ -9,7 +9,7 @@
 
 **Hook:** ⚠ — Opens with a personal time-frame ("For the past 2 years…") and a generic industry observation. The actual surprising claim ("agents are NOT the new engineers") doesn't appear until ¶4. The reader has no reason to commit before then.
 
-**Through-line:** ⚠ — The thesis is real and worth making, but it's not stated until ¶6 (`"What if instead of automated agents, a new concept gets minted: **Super Humans**"`). Paragraphs 1–3 are throat-clearing. The piece treats the late-80s internet analogy as the through-line for too long before pivoting.
+**Through-line:** ⚠ — The thesis is real and worth making, but it's not stated until ¶5 (`"What if instead of automated agents, a new concept gets minted: **Super Humans**"`). Paragraphs 1–3 are throat-clearing. The piece treats the late-80s internet analogy as the through-line for too long before pivoting.
 
 **Ending / payoff:** ✗ — The piece does not end. It cuts off mid-sentence in the "What is Agentic Development?" section: `"juggling loop between writing code by hand and orchestrating simple agent tasks like building tests for the code I wrote or simpler CSS changes."` The reader is dropped, not landed.
 
@@ -18,7 +18,7 @@
 - *Hook, option 1 — open with the contrarian claim:* "Everyone with AI tools thought agents would be the new engineers. They're not. They can't be. Here's what they actually are." Puts the surprising claim first; analogy supports it later.
 - *Hook, option 2 — open with the late-80s analogy as the lede, not the back-up:* "In the late 80s, people said the internet would reshape every industry. It didn't. It became its own industry, useful inside other businesses but never the great replacer. AI is now in the same place." Earns the comparison upfront and makes it load-bearing.
 - *Hook, option 3 — open with a concrete moment:* "Last week I watched an agent get stuck on a problem a junior engineer would have solved in a minute. It wasn't a bad model. It was the wrong job for any model." Specific, low-stakes, sets up the bigger argument.
-- *Through-line, option 1:* Cut ¶1–¶3 entirely. Open with the "Super Humans" claim from ¶6. Use the internet analogy as a single supporting paragraph after the thesis, not as the runway.
+- *Through-line, option 1:* Cut ¶1–¶3 entirely. Open with the "Super Humans" claim from ¶5. Use the internet analogy as a single supporting paragraph after the thesis, not as the runway.
 - *Through-line, option 2:* Keep the analogy as the opening but tighten ¶1–¶3 from ~150 words to ~60. The reader needs the reframe (`I think the same is happening with AI`) within the first 100 words, not the first 250.
 - *Ending, option 1:* End on the inversion — what the engineer's job actually becomes. "The new craft isn't writing code. It's reading the code your agents wrote and knowing whether they're right." Lands the contract the opening promised.
 - *Ending, option 2:* End with a stake. "If you treat your agents as colleagues, you'll plateau. If you treat them as power tools, you'll keep going." Memorable, debatable, quotable.
@@ -33,7 +33,7 @@
 > "For the past 2 years I've been working with AI tools as most of us have, we've been told over and over that software will no longer be made by humans. I think that's wrong..." *(¶1)*
 
 **Principle:** Every paragraph should make the reader more convinced or more curious. If it doesn't, cut or move it.
-**What's wrong:** The first three paragraphs do work the rest of the piece doesn't need. ¶1 sets up the disagreement, ¶2 reaches for the internet analogy, ¶3 restates the thesis ("All of that to respond…"). By the time the reader hits "Super Humans" in ¶6, the argument has already been made twice in lower-resolution form.
+**What's wrong:** The first three paragraphs do work the rest of the piece doesn't need. ¶1 sets up the disagreement, ¶2 reaches for the internet analogy, ¶3 restates the thesis ("All of that to respond…"). By the time the reader hits "Super Humans" in ¶5, the argument has already been made twice in lower-resolution form.
 **Suggested rewrite:** Cut ¶1 and ¶3. Move the analogy from ¶2 to a single supporting paragraph *after* the "Super Humans" claim. Net cut: ~150 words; the piece earns its thesis 3× faster.
 
 ### 2. Specificity — "they said" with no antecedent (¶2)
@@ -46,49 +46,37 @@
 > "...generative AI — which for the past ~3 years has been the biggest catalyst across multiple industries..." *(¶2)*
 
 **Principle:** If a period, comma, or colon would carry the same load, use it. Em dashes signal hedging or stitched half-thoughts and now read as machine-generated.
-**What's wrong:** This em dash is doing comma duty. Replace with a comma or end the sentence and start a new one with "Generative AI…".
+**What's wrong:** This em dash is doing comma duty.
 
-### 4. Style watch — em dash as connective tissue (¶2)
-> "...especially in today's market where competitiveness is rising by the day. The baseline things making that possible are better technologies, innovation, and ultimately generative AI — which for the past ~3 years..."
-
-**Principle:** Same as above.
-**What's wrong:** Two em dashes inside two consecutive sentences in ¶2. The pattern is a tell — em dashes used to extend a thought past its natural end. Cut both.
-
-### 5. Header–payoff coupling — `## What is Agentic Development?` opens with anecdote, not definition
+### 4. Header–payoff coupling — `## What is Agentic Development?` opens with anecdote, not definition
 > "## What is Agentic Development?
 >
 > For the past 1.5 years or so, I've been working in a juggling loop between writing code by hand and orchestrating simple agent tasks..." *(after the H2)*
 
 **Principle:** Headers are promises. Break the promise and the reader stops trusting you.
-**What's wrong:** The header asks "what *is* it?" The paragraph starts with "I've been working in a juggling loop" — that's *what I do*, not *what it is*. The header promised a definition; deliver one in the first sentence ("Agentic development is X"), then use the anecdote to illustrate.
+**What's wrong:** The header asks "what *is* it?" The paragraph starts with "I've been working in a juggling loop" — that's *what I do*, not *what it is*. The header promised a definition.
 
-### 6. Ending — the piece stops mid-thought
-> "...orchestrating simple agent tasks like building tests for the code I wrote or simpler CSS changes." *(end of file)*
-
-**Principle:** The ending is the contract — the opening promised insight, the ending must deliver it.
-**What's wrong:** The piece ends inside an example list, not on a landing. Even as a draft, this is the single biggest reason the post can't ship. The "What is Agentic Development?" section needs to actually answer its own question and connect back to the "Super Humans" thesis.
-
-### 7. Originality — "the internet was just its own industry" (¶2)
+### 5. Originality — "the internet was just its own industry" (¶2)
 > "Back in the late 80's they said that the internet will reshape all industries, it turned out to be just its own industry that was able to improve things in other businesses but definitely not the business killer that was promised." *(¶2)*
 
 **Principle:** The reader's time is bought by giving them something they didn't already think.
 **What's wrong:** This claim is contestable enough that it needs either an example or a more careful framing. As written, the sharper read is *"the internet did reshape every industry — retail, finance, media, advertising — it just took 20 years and the second wave (mobile + cloud)."* If the analogy is going to load-bear the AI argument, it can't be a wave-of-the-hand version of internet history.
 **Suggested rewrite:** Tighten the analogy to its strongest form: "The internet didn't kill industries. It made the businesses that adopted it well 10× more powerful, and made the ones that didn't disappear. AI is the same."
 
-### 8. Clarity — typo "prooven"
-> "Now that full autonomy has been prooven not reliable..." *(¶7)*
+### 6. Clarity — typo "prooven"
+> "Now that full autonomy has been prooven not reliable..." *(¶6)*
 
 **Principle:** If a sentence makes the reader work, the writer hasn't finished working.
-**What's wrong:** Typo: "prooven" → "proven". Also "prooven not reliable" reads awkwardly; "proven unreliable" is tighter.
+**What's wrong:** Typo: "prooven" → "proven".
 
-### 9. Voice consistency — register drifts between conversational and analytical
-> "I know this sounds yet like another random concept, but it's where the industry is naturally orbiting towards." *(¶7)*
+### 7. Voice consistency — register drifts between conversational and analytical
+> "I know this sounds yet like another random concept, but it's where the industry is naturally orbiting towards." *(¶6)*
 
 **Principle:** Pick a register and stay in it. Drift signals uncertainty about audience.
 **What's wrong:** "I know this sounds yet like another random concept" is conversational and slightly hedged. The very next clause ("the industry is naturally orbiting towards") is analyst-speak. The piece is most alive in its conversational register; lean into that and cut the analyst phrasing.
 **Suggested rewrite:** "I know — another concept. But this one is where the industry is already heading."
 
-### 10. Paragraph structure — ¶2 packs analogy + setup + claim into one block
+### 8. Paragraph structure — ¶2 packs analogy + setup + claim into one block
 > *(¶2 — entire paragraph from "I think the same..." through "...especially software.")*
 
 **Principle:** Paragraph breaks are punctuation for thought. Each break = new beat.
@@ -97,4 +85,4 @@
 
 ---
 
-*Total findings: 10 issues + verdict pass. Most are downstream of the structural problems flagged in the verdict; fixing the global structure (cut ¶1–¶3, write a real ending, deliver the H2's promise) collapses several of them.*
+*Total findings: 8 issues + verdict pass. Most are downstream of the structural problems flagged in the verdict; fixing the global structure (cut ¶1–¶3, write a real ending, deliver the H2's promise) collapses several of them.*

--- a/.claude/skills/editorial-review/md_references.md
+++ b/.claude/skills/editorial-review/md_references.md
@@ -1,0 +1,562 @@
+# Reference Anchors in Editorial Reviews
+
+This document specifies the conventions used to reference parts of a source post
+from inside an editorial review (`content/posts/<slug>.review.md`). The intent
+is to make the review file machine-parseable so editor tooling (e.g. an nvim
+plugin) can jump from an anchor in the review to the corresponding location in
+the source `.mdx` file.
+
+The review file references the source post; the source post is never modified
+by the review.
+
+---
+
+## Anchor Grammar
+
+All anchors are wrapped in italicized parentheses: `*(...)*`. They appear
+either inline at the end of a sentence, or on the line immediately following a
+blockquote.
+
+```ebnf
+anchor       = "*(" target ")*"
+target       = paragraph
+             | section
+             | section " " paragraph
+             | section " header"
+             | section ", " specifier
+             | section " scratchpad — out of scope" [ ", " reason ]
+             | range
+specifier    = "final sentence" | "post-scratchpad" | <free-form>
+reason       = <free-form prose>
+range        = paragraph "–" paragraph     ; en-dash, not hyphen
+paragraph    = "¶" integer
+section      = "§" integer { "." integer }     ; dotted path: H2, H2.H3, H2.H3.H4, ...
+```
+
+The `section` token is a **dotted path** through the heading hierarchy. The
+first integer indexes the H2, the second the H3 inside that H2, the third
+the H4 inside that H3, and so on. Depth equals the heading level minus 1
+(so H2 → 1 component, H3 → 2 components, H6 → 5 components).
+
+Examples:
+
+| Anchor          | Refers to                                                    |
+|-----------------|--------------------------------------------------------------|
+| `*(¶1)*`        | The first body paragraph of the post (top-level).            |
+| `*(¶1–¶3)*`     | A range of body paragraphs.                                  |
+| `*(§2)*`        | The entire 2nd `## ` section.                                |
+| `*(§2 ¶2)*`     | The 2nd paragraph inside the 2nd `## ` section.              |
+| `*(§3 header)*` | The text of the 3rd `## ` heading itself.                    |
+| `*(§3, final sentence)*` | The last sentence of the 3rd section.               |
+| `*(§3, post-scratchpad)*` | The first prose paragraph after a scratchpad block in §3. |
+| `*(§4 scratchpad — out of scope, noted only for completeness)*` | A token inside the scratchpad block in §4; tooling should mark it non-actionable. |
+| `*(§2.1)*`      | The 1st H3 subsection inside the 2nd H2 section.             |
+| `*(§2.1 ¶3)*`   | The 3rd paragraph inside the 1st H3 of §2.                   |
+| `*(§2.1 header)*` | The text of the 1st H3 heading inside §2.                  |
+| `*(§2.1.1 ¶1)*` | The 1st paragraph inside the 1st H4 of the 1st H3 of §2.     |
+
+---
+
+## Counting Rules
+
+These rules describe **how to walk a source `.mdx` file** and assign each
+prose block a coordinate `(§, ¶)` that matches the anchors used in a review.
+The rules are deterministic — given the same `.mdx` file, every parser
+should produce the same coordinates without needing any context from the
+review or any AI.
+
+### Top-Level Algorithm
+
+Walk the `.mdx` file line by line, tracking a **heading-path stack** and a
+**paragraph counter**:
+
+- `path` — an ordered list of integers representing the current heading
+  path, e.g. `[2, 1]` means "the 1st H3 inside the 2nd H2". Starts empty.
+- `paragraph` — the number of prose blocks seen *in the current heading
+  scope* (i.e. since the last heading of any addressable level). Starts at
+  `0`. Resets to `0` every time a heading is entered.
+- `counters[depth][parent_path]` — a sibling counter used to assign the
+  index for each heading. For each depth `d` and each path-prefix at depth
+  `d-1`, this counter tracks how many headings of depth `d` have been seen
+  under that prefix so far. (In practice a single nested dict keyed by
+  parent path will do.)
+
+Algorithm:
+
+1. **Frontmatter.** If the first non-empty line is `---`, skip every line up
+   to and including the next line that is exactly `---`. Frontmatter never
+   counts toward `§` or `¶`.
+
+2. **Body scan.** For each remaining line, classify it (see *Line Classes*
+   below) and act:
+
+   - **H1 heading** (`# `): ignored entirely. Does not change `path`,
+     `paragraph`, or any counter. (Title comes from frontmatter.)
+   - **Heading at level L ∈ {2..6}** (`## ` through `###### `):
+     - Compute `depth = L - 1` (so H2 → depth 1, H3 → depth 2, ..., H6 →
+       depth 5).
+     - Truncate `path` to the first `depth - 1` entries. (Discards any
+       deeper-nested scope we were inside.)
+     - Look up `counters[depth][tuple(path)]`, increment it, and append
+       the new value to `path`.
+     - Reset `paragraph` to `0`.
+     - The heading's coordinate is `§<path joined by '.'> header`.
+   - **Blank line**: ends the current paragraph block (if any). Doesn't
+     itself count.
+   - **Scratchpad blockquote** (see *Scratchpad Blocks* section below): the
+     entire blockquote is skipped for counting. Does not increment
+     `paragraph`.
+   - **Prose block** (anything else; see *What Counts as a Prose Block*):
+     when the block *starts*, increment `paragraph`. The block's coordinate
+     is `§<path joined by '.'> ¶<paragraph>` if `path` is non-empty, else
+     bare `¶<paragraph>`.
+
+3. **End of file.** Stop. The full set of `(path, paragraph)` coordinates
+   produced is the addressable surface of the file.
+
+### Line Classes
+
+For an unambiguous parse, every line in the body falls into exactly one
+class. Classification is based on the *raw line*, not on any rendered HTML.
+
+| Class                 | Trigger                                                    | Counting effect          |
+|-----------------------|------------------------------------------------------------|--------------------------|
+| Frontmatter delimiter | Line is exactly `---` and we're in the frontmatter region  | Skipped                  |
+| Frontmatter content   | Inside frontmatter region                                  | Skipped                  |
+| H1 heading            | Line matches `^# ` (one hash + space)                      | Ignored entirely         |
+| H2 heading            | Line matches `^## `                                        | Truncate `path` to length 0, push new H2 index, `¶ = 0` |
+| H3 heading            | Line matches `^### `                                       | Truncate `path` to length 1, push new H3 index, `¶ = 0` |
+| H4 heading            | Line matches `^#### `                                      | Truncate `path` to length 2, push new H4 index, `¶ = 0` |
+| H5 heading            | Line matches `^##### `                                     | Truncate `path` to length 3, push new H5 index, `¶ = 0` |
+| H6 heading            | Line matches `^###### `                                    | Truncate `path` to length 4, push new H6 index, `¶ = 0` |
+| Blank line            | Line contains only whitespace                              | Ends current block       |
+| Scratchpad blockquote | A blockquote whose first non-whitespace token is `Mental Note`, `TODO`, `Note to self`, or `Draft note` (see scratchpad rules) | Skipped entirely |
+| Prose block start     | First non-blank, non-heading, non-scratchpad line after a blank line or after a heading | `¶ += 1` |
+| Prose block continuation | Subsequent non-blank lines in the same block            | No change                |
+
+### What Counts as a Prose Block
+
+A prose block is any sequence of consecutive non-blank lines that is **not**
+a heading and **not** a scratchpad blockquote. The boundary is always a
+blank line (or a heading, or end of file).
+
+A prose block counts as one `¶`, regardless of what's inside it. That
+explicitly includes:
+
+- **Soft-wrapped prose.** Multiple physical lines that form one logical
+  paragraph (the common case for body text wrapped at ~80 columns).
+- **Lists.** A list (bulleted or numbered) introduced without a preceding
+  blank line, or following a paragraph as a continuation, counts as part of
+  whatever paragraph it belongs to. A list separated by blank lines on both
+  sides counts as its own `¶`.
+- **Code fences.** A fenced code block (```` ``` ````) is one `¶`. The
+  paragraph counter ticks when the opening fence is seen; the closing fence
+  ends the block.
+- **Non-scratchpad blockquotes.** A blockquote that doesn't match the
+  scratchpad first-token rule is a prose block and counts as one `¶`.
+- **MDX components / JSX.** A `<Component>...</Component>` block at the
+  top level is one `¶`. If the component contains inner prose paragraphs
+  inside MDX context, those inner paragraphs are *not* separately counted —
+  the whole component is one `¶`.
+
+Conversely, none of these count as `¶`:
+
+- Headings of any level.
+- Frontmatter.
+- Scratchpad blockquotes.
+- HTML comments (`<!-- ... -->`) that appear on their own line(s).
+- Blank lines and lines containing only whitespace.
+
+### Heading Path Rules (`§N`, `§N.M`, `§N.M.K`, ...)
+
+- A heading at level **L** (where `L ∈ {2..6}`) contributes the `(L-1)`-th
+  component of the dotted path. H2 fills component 1, H3 fills component 2,
+  etc. So `§2` is "the 2nd H2", `§2.1` is "the 1st H3 inside §2", `§2.1.3`
+  is "the 3rd H4 inside the 1st H3 of §2", and so on out to H6.
+- **H1 is ignored** — the document title comes from frontmatter; if an H1
+  appears in the body it does not change `path` or `¶`.
+- **Sibling counting is per-parent.** The index at each depth resets every
+  time you enter a new parent at the level above. Two different H3s under
+  two different H2s both start at `.1`. Concretely: if you have
+  `## A` (= §1), `### A.1` (= §1.1), `## B` (= §2), `### B.1` (= §2.1),
+  the first H3 under §2 is `.1`, *not* `.2`.
+- **Returning to a shallower level resets deeper counters.** When you exit
+  an H3 by entering a new H2 (or by reaching EOF), the H3 counter for the
+  *next* H2 you enter starts fresh at `.1`.
+- **Level-skipping is allowed but discouraged.** If a doc jumps from H2
+  straight to H4 (no H3 between), the H4's coordinate uses its actual
+  depth: H4 → `§N..K`. Empty path components are written as nothing
+  between dots, e.g. `§2..1` for "1st H4 under §2 with no H3 layer".
+  (Parsers should treat the empty component as index `0`, addressable but
+  unusual; in practice well-formed posts won't hit this.)
+- **Pre-heading region.** Any prose block before the first H2 has no `§`
+  prefix. Address it with bare `¶N`. Paragraphs in this region are numbered
+  starting at `¶1` and reset to `0` when the first H2 is entered.
+
+### Paragraph Rules (`¶N`)
+
+- `¶N` indexes the Nth prose block within **the current heading scope**,
+  counting from 1.
+- The "current heading scope" is whatever heading was most recently entered
+  at *any* addressable level (H2–H6). Crossing a heading of any level
+  resets `¶` to `0`.
+- Numbering is local: `§1 ¶3`, `§2 ¶3`, and `§2.1 ¶3` are three different
+  paragraphs, each the 3rd within its own scope.
+- Headings, scratchpad blocks, and HTML comments do not interrupt the
+  count — they are simply absent from it. Two prose blocks separated only
+  by a scratchpad block are still consecutive (`¶3` then `¶4`).
+- A prose block that appears between an H2 and that H2's first child H3
+  belongs to the H2's scope (e.g. `§2 ¶1`). A prose block appearing after
+  the H3 belongs to the H3's scope (`§2.1 ¶1`), **not** to the H2's
+  scope.
+
+### Ranges
+
+- Ranges use an en-dash (`–`, U+2013), not a hyphen or em-dash.
+- `*(¶1–¶3)*` means paragraphs 1, 2, and 3 inclusive.
+- Ranges across sections are not supported in this convention; if needed,
+  list the sections explicitly.
+
+### Specifiers
+
+The free-form specifier slot (`*(§N, <specifier>)*`) is used for sub-paragraph
+locations the integer scheme can't address. Recognized specifiers:
+
+- `final sentence` — the last sentence of the section or paragraph indicated.
+  Sentence boundary is the *last* `. `, `! `, or `? ` in the prose block,
+  or the end of the block.
+- `post-scratchpad` — the first prose paragraph appearing after a scratchpad
+  blockquote inside the named section.
+- `header` — the H2 heading text of the named section.
+
+Specifiers are advisory; tooling can treat unknown specifiers as a fallback to
+jumping to the section start.
+
+---
+
+## Worked Example
+
+The following `.mdx` is annotated with the coordinates every line resolves
+to. Lines marked `—` do not contribute to `§` or `¶`.
+
+```
+                                                          coord
+─────────────────────────────────────────────────────────────────
+---                                                       —     (frontmatter open)
+title: 'Example post'                                     —
+date: '2026-05-16'                                        —
+published: false                                          —
+---                                                       —     (frontmatter close)
+                                                          —     (blank)
+First body paragraph, wrapped over                        ¶1
+two physical lines.                                       ¶1
+                                                          —
+A second body paragraph before any                        ¶2
+H2 heading.                                               ¶2
+                                                          —
+## But why X?                                             §1 header
+                                                          —
+First paragraph inside §1, before any                     §1 ¶1
+H3.                                                       §1 ¶1
+                                                          —
+### A subhead                                             §1.1 header
+                                                          —
+First paragraph under the H3.                             §1.1 ¶1
+                                                          —
+Second paragraph under the H3, which                      §1.1 ¶2
+spans two lines.                                          §1.1 ¶2
+                                                          —
+> Mental Note: remember to add an example here            —     (scratchpad, skipped)
+> about the dot-com era.                                  —
+                                                          —
+Third paragraph under §1.1, written                       §1.1 ¶3
+after the scratchpad. Addressable as
+either `§1.1 ¶3` or `§1.1, post-scratchpad`.              §1.1 ¶3
+                                                          —
+### Another subhead                                       §1.2 header
+                                                          —
+First paragraph under the second H3.                      §1.2 ¶1
+                                                          —
+## How can you catch up?                                  §2 header
+                                                          —
+First paragraph in §2.                                    §2 ¶1
+                                                          —
+### A subhead in §2                                       §2.1 header
+                                                          —
+First paragraph here — note the index                     §2.1 ¶1
+reset; this is `§2.1`, not `§1.3`.                        §2.1 ¶1
+                                                          —
+> Mental Note: outline only, not                          —     (scratchpad)
+> written yet.                                            —
+```
+
+Resulting addressable coordinates:
+
+- Pre-section region: `¶1`, `¶2`.
+- `§1 header`, `§1 ¶1`.
+- `§1.1 header`, `§1.1 ¶1`, `§1.1 ¶2`, `§1.1 ¶3` (also reachable as
+  `§1.1, post-scratchpad`).
+- `§1.2 header`, `§1.2 ¶1`.
+- `§2 header`, `§2 ¶1`.
+- `§2.1 header`, `§2.1` has only a scratchpad after its first paragraph;
+  `§2.1 ¶1` is the only `¶` coordinate inside it.
+
+Notice that:
+
+- Entering `§1.1` reset `¶` to `0`, so the first paragraph after `### A
+  subhead` is `§1.1 ¶1`, not `§1 ¶2`.
+- Entering `§1.2` reset `¶` again. Two paragraphs under `§1.1` and one
+  under `§1.2` is the right count — they're in different scopes.
+- Entering `§2` truncated `path` to length 0 first, then pushed the new H2
+  index — so `§1.1` is no longer "current" once we're past `## How can you
+  catch up?`.
+- The H3 under §2 starts at `§2.1`, not at `§1.3` — sibling indices reset
+  per parent.
+
+### Worst-Case Edge Cases
+
+| Source pattern                                         | Resolves to                |
+|--------------------------------------------------------|----------------------------|
+| Blank line between two prose lines                     | Two paragraphs (`¶N`, `¶N+1`) |
+| Two H2 headings with no body between them              | `§N header`, `§N+1 header`; `§N` has zero paragraphs |
+| Heading deeper than H2 (`### Subhead`)                 | Opens a new heading scope; `¶` resets to `0`; coordinate gets one more dotted component (`§N.M`, `§N.M.K`, ...). Prose under the H3 belongs to the H3's scope, not the H2's. |
+| H1 inside the body (`# Title`)                         | Ignored; does not change `path` or `¶`. Title belongs in frontmatter. |
+| Level-skipping headings (H2 then H4 with no H3)        | The H4's coordinate uses its real depth: `§N..K`. The empty middle component is index `0`; well-formed posts shouldn't produce this. |
+| H3 inside `§N` with a prose paragraph between H2 and H3 | That paragraph is `§N ¶1`. The first paragraph under the H3 is `§N.1 ¶1` — they are different scopes. |
+| Two adjacent H3s under one H2 with no prose between    | `§N.1 header`, `§N.2 header`; both have zero `¶` coordinates until prose appears under one of them. |
+| Code fence opened but never closed (malformed)         | Treated as one paragraph from the opening fence to end of file |
+| HTML comment between two paragraphs (`<!-- ... -->`)   | Treated like a blank line for counting purposes |
+| Scratchpad blockquote with mixed `> Mental Note:` and prose continuation lines | Entire blockquote skipped; the next prose block after the blockquote increments `¶` |
+| Paragraph that visually contains a list (no blank line before list) | Single `¶` covering both intro line and list items |
+| Bare list after a blank line (no preceding intro)      | The list is its own `¶`     |
+
+---
+
+## Quote Blocks
+
+Every Issue in an editorial review anchors to the source post with a Markdown
+blockquote of the exact quoted text, immediately followed by the anchor on the
+same line:
+
+```markdown
+> "Information access is the biggest bottleneck for R&D, entire years get invested into gathering information during research and after into development." *(§2 ¶1)*
+```
+
+Or, for longer or multi-line quotes, the anchor goes on the line after the
+blockquote:
+
+```markdown
+> "What we all seem to be misunderstanding is that models learn from past
+> human behavior and have no short term memory..." *(§3 ¶1)*
+```
+
+Rules:
+
+- The quoted text must appear verbatim in the source post (modulo whitespace
+  collapse across soft-wraps). Tooling can use the quote as a confirmation
+  match after jumping to the `¶/§` location.
+- A single Issue may quote multiple anchors (e.g. when comparing two
+  paragraphs). In that case, list each quote+anchor as its own blockquote.
+
+---
+
+## Verdict-Pass Markers
+
+The Verdict pass uses three status markers, always immediately after the
+dimension name and a bold colon:
+
+| Marker | Meaning                                                                |
+|--------|------------------------------------------------------------------------|
+| `✓`    | Working as-is. No rewrite directions generated.                        |
+| `⚠`    | Has problems but the structural shape is recoverable. Rewrite directions given. |
+| `✗`    | Broken or missing. Rewrite directions given.                           |
+
+Markers are U+2713 (`✓`), U+26A0 (`⚠`), U+2717 (`✗`).
+
+---
+
+## Issue Headings
+
+Issues are H3 (`### `) and follow a fixed format:
+
+```
+### N. <Dimension> — <short title>
+```
+
+Where:
+- `N` is a 1-based ordinal across the Issues list.
+- `<Dimension>` is one of the 11 rubric dimensions (see `SKILL.md`).
+- `—` is an em-dash (U+2014).
+- `<short title>` is a phrase, not a sentence; no terminal punctuation.
+
+The body of every Issue contains in order:
+
+1. One or more `> "quote" *(anchor)*` blocks.
+2. `**Principle:** ...` line.
+3. `**What's wrong:** ...` line.
+4. (Style B and C only) `**Suggested rewrite:** ...` or
+   `**Suggested rewrite** *(only for tier-2 judgment issues — flow / structure / voice / originality)*: ...`.
+
+---
+
+## Scratchpad Blocks and Out-of-Scope Anchors
+
+Draft posts often contain author-side scratchpad blockquotes that the writer
+left for themselves while drafting. These are drafting aids, not copy that
+will ship, and the editorial-review skill treats them as out of scope. The
+anchor conventions below let tooling reflect that distinction (e.g. dim the
+target, suppress it from jump-to-issue navigation, or render it differently).
+
+### Detecting a Scratchpad Block
+
+A blockquote is a scratchpad block if either is true:
+
+1. **First-token rule.** The first non-whitespace token after the opening `>`
+   is one of: `Mental Note`, `TODO`, `Note to self`, `Draft note`. Tokens are
+   case-sensitive. Match is anchored to the start of the blockquote, not
+   anywhere inside it.
+
+   ```markdown
+   > Mental Note: I want to add a note about the projects I'm working on
+   > to mitigate this like tusk and superhuman
+   ```
+
+2. **Intent rule.** The blockquote's content is plainly an instruction the
+   writer wrote to themselves ("I want to talk about…", "remember to
+   mention…", "not a tutorial but rather a suggestion of how…"). Tooling
+   should treat the first-token rule as authoritative and only fall back to
+   the intent rule when explicitly opted in — the intent rule requires
+   judgment and is meant for the reviewer, not the parser.
+
+### Paragraph-Count Effect
+
+Scratchpad blocks **do not** count as paragraphs. They are skipped when
+resolving `¶N` and `§N ¶M` anchors, the same way headings are skipped. A
+section whose body is *only* a scratchpad block has zero paragraphs and
+cannot be addressed with `§N ¶M` — only `§N header` and `§N scratchpad`
+anchors are valid for it.
+
+### Anchoring to Content Inside a Scratchpad
+
+When the review must reference a token inside a scratchpad block (typo
+clusters that include scratchpad-resident typos are the typical case), use
+the scratchpad anchor form:
+
+```
+*(§N scratchpad — out of scope, <free-form reason>)*
+```
+
+Examples used in real reviews:
+
+```markdown
+> "reacher context" *(§3 scratchpad — out of scope, noted only for completeness)*
+> "ultimatly"       *(§3 scratchpad — out of scope, noted only for completeness)*
+> "sugestion"       *(§4 scratchpad — out of scope, noted only because it's in a header users will skim)*
+```
+
+Anchor grammar:
+
+```ebnf
+scratchpad-anchor = "*(" section " scratchpad" " — out of scope" [ ", " reason ] ")*"
+section           = "§" integer { "." integer }     ; same dotted form as elsewhere
+reason            = <free-form prose>
+```
+
+The scope identified by `section` can be at any heading depth — a
+scratchpad block can live under an H2 (`§3 scratchpad — ...`), an H3
+(`§2.1 scratchpad — ...`), or deeper.
+
+Rules:
+
+- The `— out of scope` clause is mandatory. Its presence is how tooling
+  detects that the anchor points into a scratchpad rather than into prose.
+- The free-form `reason` is optional but recommended; it tells the reader
+  *why* the scratchpad item was worth surfacing despite being out of scope.
+- Scratchpad anchors **only** appear inside Issue 5-style typo clusters or
+  occasionally inside the verdict's notes about an unwritten landing.
+  Outside those contexts, scratchpad blocks are never quoted and never
+  flagged as paragraph-structure or voice issues.
+
+### Post-Scratchpad Anchor
+
+When a prose paragraph follows a scratchpad block inside the same section
+and needs to be referenced, use the `post-scratchpad` specifier:
+
+```
+*(§N, post-scratchpad)*
+```
+
+This resolves to the first prose paragraph appearing after a scratchpad
+blockquote inside section `N`. It's necessary because `§N ¶M` numbering
+already skips scratchpad blocks, so a sentence like "the paragraph right
+after the Mental Note" can't be addressed with `¶M` alone without the
+reader recounting from the section start.
+
+Example:
+
+```markdown
+> "Modern models like Claude, Gemini, ChatGPT…" *(§3, post-scratchpad)*
+```
+
+### Status-Line Convention
+
+When a post contains scratchpad blocks, the review's status line notes
+them so a downstream reader (or tool) doesn't treat the post as a
+finished draft:
+
+```
+*Reviewed YYYY-MM-DD · word count: ~N · status: published:false (mid-draft;
+the `> Mental Note:` blocks under §4 and §5 are author scratchpad, out of
+scope for this pass)*
+```
+
+The phrase `out of scope for this pass` is the canonical signal. Tooling
+parsing review headers can use this phrase to decide whether to enable
+scratchpad-aware rendering for the rest of the file.
+
+### Verdict Interaction
+
+The Ending / payoff verdict still applies even when the would-be landing
+is scratchpad. The review marks it `✗` and the verdict line should call
+out the scratchpad status explicitly — e.g. *"§4 and §5 are scratchpad;
+the landing is unwritten, not broken."* That distinction tells the writer
+the next action is *draft the close*, not *rewrite the close*.
+
+---
+
+## Summary for Tooling
+
+To resolve any anchor to a source-file location:
+
+1. Open the source post indicated by the review filename:
+   `content/posts/<slug>.review.md` → `content/posts/<slug>.mdx`.
+2. Skip the YAML frontmatter.
+3. Run the *Top-Level Algorithm* above against the body, building a map
+   from each coordinate (`(path, paragraph)` or `(path, "header")`) to its
+   starting line number. Stop only when EOF is reached or you've passed
+   the target.
+
+Per-anchor-shape resolution against that map:
+
+- **`*(¶N)*`** (no `§`): look up coordinate `((), N)` — paragraph `N` in
+  the pre-section region.
+- **`*(§N)*` / `*(§N.M)*` / `*(§N.M.K)*` etc.**: parse the dotted path
+  into a tuple of integers; place the cursor on the line of that heading.
+  Equivalent to `*(§<path> header)*`.
+- **`*(§<path> ¶M)*`**: look up coordinate `(<path>, M)`.
+- **`*(§<path> header)*`**: place the cursor on the heading line whose
+  path is `<path>`.
+- **`*(§<path>, final sentence)*`**: jump to the paragraph the path
+  refers to (or to its last paragraph if the path names a heading), then
+  move to the last sentence boundary (`. `, `! `, or `? `) inside it.
+- **`*(§<path>, post-scratchpad)*`**: scan the body of the scope named by
+  `<path>` (a section at any depth), find the first scratchpad blockquote,
+  then place the cursor on the first prose paragraph after it.
+- **`*(§<path> scratchpad — out of scope, ...)*`**: place the cursor on the
+  first line of the scratchpad blockquote inside the scope named by
+  `<path>`. Tooling should mark this jump as non-actionable (e.g. via a
+  different highlight group or a status-line warning) so the writer knows
+  the target isn't shipping copy.
+- **Range `*(¶A–¶B)*`**: resolve start of paragraph `A` and (optionally)
+  highlight through the end of paragraph `B`. Ranges only span paragraphs
+  inside the same scope.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ docs/superpowers/
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# editorial-review skill outputs
+content/posts/*.review.md

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": ">=24.12.0"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.6",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: ^16.2.6
+        version: 16.2.6(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -438,6 +441,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.2.6':
+    resolution: {integrity: sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2263,6 +2272,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2790,6 +2802,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.1':
     optional: true
+
+  '@next/third-parties@16.2.6(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      next: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5030,6 +5048,8 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  third-party-capital@1.0.20: {}
 
   tinyglobby@0.2.15:
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { FaGithub, FaInstagram, FaLinkedin, FaEnvelope } from "react-icons/fa6";
 import Navigation from "@/components/Navigation";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 
 const roboto = Roboto({
   variable: '--font-roboto',
@@ -108,6 +109,7 @@ export default function RootLayout({
         <Analytics />
         <SpeedInsights />
       </body>
+      <GoogleAnalytics gaId="G-10JWQ5PYE7" />
     </html>
   );
 }

--- a/src/app/writing/[slug]/_components/DictationButton.tsx
+++ b/src/app/writing/[slug]/_components/DictationButton.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { FiPlay, FiPause, FiSquare } from 'react-icons/fi';
+
+type Status = 'idle' | 'playing' | 'paused';
+
+type Props = {
+  text: string;
+};
+
+const subscribe = () => () => {};
+const getSupported = () => 'speechSynthesis' in window;
+const getServerSupported = () => false;
+
+export default function DictationButton({ text }: Props) {
+  const supported = useSyncExternalStore(
+    subscribe,
+    getSupported,
+    getServerSupported,
+  );
+  const [status, setStatus] = useState<Status>('idle');
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+        window.speechSynthesis.cancel();
+      }
+    };
+  }, []);
+
+  if (!supported) {
+    return null;
+  }
+
+  function play() {
+    const synth = window.speechSynthesis;
+
+    if (status === 'paused') {
+      synth.resume();
+      setStatus('playing');
+      return;
+    }
+
+    synth.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    utterance.onend = () => setStatus('idle');
+    utterance.onerror = () => setStatus('idle');
+    utteranceRef.current = utterance;
+    synth.speak(utterance);
+    setStatus('playing');
+  }
+
+  function pause() {
+    window.speechSynthesis.pause();
+    setStatus('paused');
+  }
+
+  function stop() {
+    window.speechSynthesis.cancel();
+    setStatus('idle');
+  }
+
+  const isPlaying = status === 'playing';
+
+  return (
+    <div className="flex items-center gap-1 print:hidden" role="group" aria-label="Listen to this post">
+      <button
+        type="button"
+        onClick={isPlaying ? pause : play}
+        className="btn btn-xs btn-ghost"
+        aria-label={isPlaying ? 'Pause dictation' : 'Play dictation'}
+      >
+        {isPlaying ? <FiPause /> : <FiPlay />}
+        <span>{isPlaying ? 'Pause' : status === 'paused' ? 'Resume' : 'Listen'}</span>
+      </button>
+      {status !== 'idle' && (
+        <button
+          type="button"
+          onClick={stop}
+          className="btn btn-xs btn-ghost"
+          aria-label="Stop dictation"
+        >
+          <FiSquare />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import type { Metadata } from 'next';
-import { getPostBySlug, getAllPostSlugs } from '@/lib/posts';
+import { getPostBySlug, getAllPostSlugs, toSpokenText } from '@/lib/posts';
+import DictationButton from './_components/DictationButton';
 
 type Params = { slug: string };
 
@@ -54,7 +55,12 @@ export default async function PostPage({
     <article>
       <header className="mb-8">
         <h1 className="text-2xl font-bold">{post.title}</h1>
-        <p className="text-gray-500 mt-1">{formattedDate}</p>
+        <div className="flex items-center gap-2 text-gray-500 mt-1">
+          <span>
+            {formattedDate} · {post.readingMinutes} min read
+          </span>
+          <DictationButton text={toSpokenText(post.content)} />
+        </div>
         {post.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mt-2">
             {post.tags.map((tag) => (

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -46,7 +46,9 @@ export default function WritingPage() {
               >
                 <h3 className="text-lg font-semibold">{post.title}</h3>
               </Link>
-              <p className="text-sm text-gray-500">{formattedDate}</p>
+              <p className="text-sm text-gray-500">
+                {formattedDate} · {post.readingMinutes} min read
+              </p>
               <p className="text-gray-700 mt-1">{post.description}</p>
             </li>
           );

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -19,6 +19,13 @@ export type Post = PostMeta & {
 const POSTS_DIR = path.join(process.cwd(), 'content', 'posts');
 const WORDS_PER_MINUTE = 225;
 
+function showsDrafts(): boolean {
+  return (
+    process.env.NODE_ENV === 'development' ||
+    process.env.VERCEL_ENV === 'preview'
+  );
+}
+
 function countWords(markdown: string): number {
   const text = markdown
     .replace(/```[\s\S]*?```/g, ' ')
@@ -73,7 +80,7 @@ export function getAllPosts(): PostMeta[] {
         readingMinutes: getReadingMinutes(content),
       };
     })
-    .filter((post) => post.published || process.env.NODE_ENV === 'development')
+    .filter((post) => post.published || showsDrafts())
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   return posts;
@@ -101,7 +108,7 @@ export function getPostBySlug(slug: string): Post | null {
     content,
   };
 
-  if (!post.published && process.env.NODE_ENV !== 'development') {
+  if (!post.published && !showsDrafts()) {
     return null;
   }
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -9,6 +9,7 @@ export type PostMeta = {
   description: string;
   tags: string[];
   published: boolean;
+  readingMinutes: number;
 };
 
 export type Post = PostMeta & {
@@ -16,6 +17,37 @@ export type Post = PostMeta & {
 };
 
 const POSTS_DIR = path.join(process.cwd(), 'content', 'posts');
+const WORDS_PER_MINUTE = 225;
+
+function countWords(markdown: string): number {
+  const text = markdown
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  const words = text.match(/\b[\w'’-]+\b/g);
+  return words ? words.length : 0;
+}
+
+function getReadingMinutes(markdown: string): number {
+  return Math.max(1, Math.ceil(countWords(markdown) / WORDS_PER_MINUTE));
+}
+
+export function toSpokenText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/^>\s?/gm, '')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*\d+\.\s+/gm, '')
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(.*?)\1/g, '$2')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 export function getAllPosts(): PostMeta[] {
   if (!fs.existsSync(POSTS_DIR)) {
@@ -29,7 +61,7 @@ export function getAllPosts(): PostMeta[] {
       const slug = filename.replace(/\.mdx$/, '');
       const filePath = path.join(POSTS_DIR, filename);
       const fileContent = fs.readFileSync(filePath, 'utf-8');
-      const { data } = matter(fileContent);
+      const { data, content } = matter(fileContent);
 
       return {
         slug,
@@ -38,9 +70,10 @@ export function getAllPosts(): PostMeta[] {
         description: data.description ?? '',
         tags: data.tags ?? [],
         published: data.published ?? false,
+        readingMinutes: getReadingMinutes(content),
       };
     })
-    .filter((post) => post.published)
+    .filter((post) => post.published || process.env.NODE_ENV === 'development')
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   return posts;
@@ -64,10 +97,11 @@ export function getPostBySlug(slug: string): Post | null {
     description: data.description ?? '',
     tags: data.tags ?? [],
     published: data.published ?? false,
+    readingMinutes: getReadingMinutes(content),
     content,
   };
 
-  if (!post.published) {
+  if (!post.published && process.env.NODE_ENV !== 'development') {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Batches together unmerged local work on top of `origin/main`:

- **Editorial-review skill** — initial add, calibration fixes, two rounds of verdict-tier-duplication hardening, and a new `md_references.md` spec that defines how reviews reference parts of a source post (¶N, §N, §N.M dotted heading paths, scratchpad anchors, ranges). `SKILL.md` now requires those conventions so review output is machine-parseable by editor tooling.
- **Writing pages** — reading time on listing + post pages, a `DictationButton` backed by a markdown-stripping `toSpokenText()`, unpublished posts visible in development, and Google Analytics via `@next/third-parties`.

## Test plan

- [ ] `pnpm dev` and verify the writing index shows reading time on each post.
- [ ] Visit a post page and verify reading time + dictation button render; click dictation and confirm the spoken stream skips code fences / formatting.
- [ ] With `NODE_ENV=development`, confirm an unpublished post is reachable via its slug.
- [ ] `pnpm build` succeeds.
- [ ] Verify Google Analytics tag loads in the browser network panel.