### PR TITLE
Publish post: The start of the Super Human era

### DIFF
--- a/content/posts/the-start-of-the-super-human-era.mdx
+++ b/content/posts/the-start-of-the-super-human-era.mdx
@@ -1,0 +1,96 @@
+---
+title: 'The start of the Super Human era'
+date: '2026-05-19'
+description: "Agents aren't the future. Humans who think with models are. Here's why they're already pulling ahead."
+tags: ['agents', 'AI', 'agentic', 'humans', 'software']
+published: true
+---
+
+Fully autonomous agents aren't the future. Humans who think with models are. And
+they are already pulling ahead of everyone who's still waiting for models to
+mature.
+
+---
+
+## What is a Super Human?
+
+A Super Human is not someone with better tools. It's someone whose bottleneck
+has shifted.
+
+Information access has been the biggest bottleneck to figuring things out
+throughout human history.
+
+Models do in seconds what used to take weeks of reading.
+
+So the bottleneck shifts to judgment. Reasoning, decision-making, the ideas
+you can't quite explain. The more context you have, the better the decisions
+you make. Models take care of the context while you develop the right
+judgment.
+
+In practice this shift looks small in the moment and huge in aggregate. Looking
+something up takes minutes instead of an afternoon. Drafting takes one pass
+instead of three. The hard part of the day stops being *finding the answer* and
+becomes *deciding which of three answers is the right one to act on*.
+
+Judgment isn't built from past information alone, or from what's in front of
+you right now. It comes from past experimentation, from things you noticed
+without trying to. Models don't have that.
+
+Demis Hassabis made this point about Go: top players often choose moves they
+can't fully explain. They just feel right. [DeepMind did teach AlphaGo that
+intuition](https://www.technologyreview.com/2022/02/23/1045016/ai-deepmind-demis-hassabis-alphafold/),
+but only Go's. Yours is still yours to build.
+
+So we run a loop. Explore with models, build judgment from what comes back,
+fail in public, sharpen, repeat.
+
+## Even when agents catch up
+
+The autonomous alternative is arriving faster than the people waiting for it
+expected.
+
+[METR's Time Horizon 1.1](https://metr.org/blog/2026-1-29-time-horizon-1-1/),
+published January 2026, measured Claude Opus 4.5 completing about five hours of
+work autonomously at 50% success. The doubling time accelerated from seven
+months to under three. The benchmark is starting to saturate; METR is racing to
+build tasks the latest models can't beat.
+
+Ethan Mollick, who used to call this era *"co-intelligence,"* now calls it
+[something else](https://www.oneusefulthing.org/p/the-shape-of-the-thing):
+*"This is an era of managing AIs, rather than working with them."* You give an
+agent hours of work and review the finished product.
+
+That's the same bottleneck shift, accelerated. *A Super Human is someone whose
+bottleneck has already shifted to judgment.* The agent era doesn't change that.
+It makes it the only thing that matters.
+
+The smart voices in the field have been saying the same thing for a year.
+Anthropic recommends [starting with the simplest non-agentic
+solution](https://www.anthropic.com/research/building-effective-agents); agent
+autonomy *"increases costs and compounds errors."* Karpathy calls for an
+[autonomy slider](https://www.latent.space/p/s3), not a slider stuck at 100%.
+Simon Willison spent late 2025 [designing agentic
+loops](https://simonw.substack.com/p/designing-agentic-loops) carefully, not
+turning them loose. The people who get the most out of these systems are the
+ones who know when to grab the wheel.
+
+That judgment gets built in the loop. The people who started running it a year
+ago will be the ones managing agents well next year. Everyone else will be
+reviewing output they can't grade.
+
+## Stop waiting
+
+Models are already good enough, and the people using them are already pulling
+ahead.
+
+You can see it already. I built [tusk](https://github.com/germanamz/tusk) over
+eight weeks. The idea kept outrunning the code, until the complexity itself was
+the signal. I made the call: scrap the task-management CLI I'd started with,
+rewrite it as an agent-first brain. The information for that call was already in
+front of me. What I needed was the judgment to trust it.
+
+Better judgment improves how you use these models, which accelerates your
+access to information, which sharpens judgment again. That loop compounds.
+While others wait.
+
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,7 @@ export default function Home() {
                   year: 'numeric',
                   month: 'long',
                   day: 'numeric',
+                  timeZone: 'UTC',
                 },
               );
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const postEntries: MetadataRoute.Sitemap = getAllPosts().map((post) => ({
     url: `${baseUrl}/writing/${post.slug}`,
-    lastModified: new Date(post.date),
+    lastModified: new Date(post.updated ?? post.date),
     changeFrequency: 'monthly',
     priority: 0.6,
   }));

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -45,12 +45,17 @@ export default async function PostPage({
     notFound();
   }
 
-  const formattedDate = new Date(post.date).toLocaleDateString('en-US', {
+  const dateFormat: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
     timeZone: 'UTC',
-  });
+  };
+  const formattedDate = new Date(post.date).toLocaleDateString('en-US', dateFormat);
+  const formattedUpdated =
+    post.updated && post.updated !== post.date
+      ? new Date(post.updated).toLocaleDateString('en-US', dateFormat)
+      : null;
 
   return (
     <article>
@@ -62,6 +67,9 @@ export default async function PostPage({
           </span>
           <DictationButton text={toSpokenText(post.content)} />
         </div>
+        {formattedUpdated && (
+          <p className="text-sm text-gray-400 mt-1">Updated {formattedUpdated}</p>
+        )}
         {post.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mt-2">
             {post.tags.map((tag) => (

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -49,6 +49,7 @@ export default async function PostPage({
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 
   return (

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -35,6 +35,7 @@ export default function WritingPage() {
               year: 'numeric',
               month: 'long',
               day: 'numeric',
+              timeZone: 'UTC',
             },
           );
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -6,6 +6,7 @@ export type PostMeta = {
   slug: string;
   title: string;
   date: string;
+  updated?: string;
   description: string;
   tags: string[];
   published: boolean;
@@ -74,6 +75,7 @@ export function getAllPosts(): PostMeta[] {
         slug,
         title: data.title ?? slug,
         date: data.date ?? '',
+        updated: data.updated,
         description: data.description ?? '',
         tags: data.tags ?? [],
         published: data.published ?? false,
@@ -101,6 +103,7 @@ export function getPostBySlug(slug: string): Post | null {
     slug,
     title: data.title ?? slug,
     date: data.date ?? '',
+    updated: data.updated,
     description: data.description ?? '',
     tags: data.tags ?? [],
     published: data.published ?? false,


### PR DESCRIPTION
## Summary
- Publishes `content/posts/the-start-of-the-super-human-era.mdx` (flips `published: false → true`).
- Argues that models have shifted the bottleneck from information access to judgment, and that humans running the loop with models are already pulling ahead of those waiting for full autonomy.
- Went through editorial-review: hook, through-line, and ending all ✓; structural edits applied (cut a convoluted judgment-intuition paragraph, sharpened §2 header to "Even when agents catch up", added concrete tusk-as-example in §3).

## Test plan
- [x] `pnpm dev` — post renders at `/writing/the-start-of-the-super-human-era` (verified via Playwright; title, all three H2s, hook, and close all render; no console errors)
- [x] Post appears in `/writing` listing (verified — appears as newest entry above `hello-world`)
- [x] Post appears in `sitemap.xml` (verified — `https://germanamz.com/writing/the-start-of-the-super-human-era` with `lastmod` 2026-05-19)
- [x] External links spot-checked — all 7 return 200: METR, Mollick (One Useful Thing), Anthropic (Building effective agents), Karpathy (Latent Space), Simon Willison (Designing agentic loops), MIT Tech Review (Hassabis/AlphaFold), tusk repo
- [x] `pnpm build` clean (exit 0; route `/writing/the-start-of-the-super-human-era` generated)
- [x] `pnpm lint` clean (exit 0)