### PR TITLE
Gitignore .playwright-mcp/ session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 
 # editorial-review skill outputs
 content/posts/*.review.md
+
+# playwright-mcp session artifacts
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Adds `.playwright-mcp/` to `.gitignore`. The Playwright MCP server writes session artifacts (page snapshots, console logs) into this directory whenever it's used in the repo, and they were showing up as untracked.

## Test plan
- [x] `.playwright-mcp/` no longer appears in `git status` after a Playwright session