### PR TITLE
Add X profile to social links

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,14 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Roboto } from "next/font/google";
 import "./globals.css";
 import Link from 'next/link';
-import { FaGithub, FaInstagram, FaLinkedin, FaEnvelope } from "react-icons/fa6";
+import { FaGithub, FaInstagram, FaLinkedin, FaEnvelope, FaXTwitter } from "react-icons/fa6";
 import Navigation from "@/components/Navigation";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -92,6 +92,9 @@ export default function RootLayout({
               <ul className="flex flex-row gap-4">
                 <li>
                   <Link href="mailto:iam@germanamz.com" target="_blank"><FaEnvelope className="w-4 h-4" /></Link>
+                </li>
+                <li>
+                  <Link href="https://x.com/germanamz" target="_blank"><FaXTwitter className="w-4 h-4" /></Link>
                 </li>
                 <li>
                   <Link href="https://github.com/germanamz" target="_blank"><FaGithub className="w-4 h-4" /></Link>


### PR DESCRIPTION
## Summary
- Add an X (Twitter) link to the footer social icon row in `src/app/layout.tsx`, using `FaXTwitter` and pointing to https://x.com/germanamz. The site previously linked GitHub, LinkedIn, and Instagram but not X.
- Configure `@typescript-eslint/no-unused-vars` to ignore `_`-prefixed identifiers, clearing the pre-existing warning on the intentional `_content` destructure-omit in `src/lib/posts.ts`.

## Test plan
- `pnpm lint` passes with no warnings.