### PR TITLE
Add private vault submodule at notes/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "notes"]
+	path = notes
+	url = git@github.com:germanamz/vault.git


### PR DESCRIPTION
## Summary
- Mounts the private `germanamz/vault` repo as a git submodule at `notes/`
- Adds `.gitmodules` recording the submodule path and URL
- Public repo only exposes the submodule URL and pinned commit SHA; contents stay private

## Test plan
- [ ] Fresh clone with `git clone --recurse-submodules` populates `notes/`
- [ ] `git clone` without the flag still works; `git submodule update --init` then populates `notes/`
- [ ] Visitors without access to `germanamz/vault` see a broken link in the GitHub tree but the parent repo still clones cleanly